### PR TITLE
fixes an example for filtering out everything except untagged log messages

### DIFF
--- a/user-guide/logging/README.md
+++ b/user-guide/logging/README.md
@@ -208,7 +208,7 @@ The following log tag filters are considered _special_ in that they offer log ou
 | Special Level | Description | Example |
 | --- | --- | --- |
 | _all | Print log messages from all tags, except for untagged messages | `LOG_TAGS=_all start_service.sh` |
-| _untagged | Print log messages aren't tagged | `LOG_TAGS=_all start_service.sh` |
+| _untagged | Print log messages aren't tagged | `LOG_TAGS=_untagged start_service.sh` |
 
 ## Standards
 


### PR DESCRIPTION
I'm pretty sure this modification is correct?