### PR TITLE
Improve grammar for glossary definition of `endpoint`

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -50,7 +50,7 @@ The consumer is the infrastructure that runs a subscription [reader](/glossary.m
 
 ## Endpoint
 
-An endpoint is the source process that a message comes from or the destination process where it is sent is _endpoint_. The term _endpoint_ is often used informally as a substitute for _service_.
+An endpoint is the source process that a message comes from or the destination process where it is sent. The term _endpoint_ is often used informally as a substitute for _service_.
 
 ## Entity
 


### PR DESCRIPTION
Reviewing the history of the glossary.md file, it appears that the corrupted definition of endpoint was lifted whole from some other source.  The dangling predicate in the copy hints that maybe a sentence was lost somewhere.

The edits provided here are grammatically consistent with the rest of the definition, but do not attempt to revert the original corruption (if any).