### PR TITLE
list messages command is updated to print messages

### DIFF
--- a/examples/quickstart.md
+++ b/examples/quickstart.md
@@ -123,12 +123,12 @@ ruby demos/write_and_read.rb
 
 ## List the Messages in the Message Store Database
 
-Now that a message has been added to the message store, you can list the contents of the message store using a command line tool that is included with the Eventide toolkit.
+Now that a message has been added to the message store, you can print the contents of the message store using a command line tool that is included with the Eventide toolkit.
 
 From the command line, run:
 
 ``` bash
-bundle exec evt-pg-list-messages
+bundle exec evt-pg-print-messages
 ```
 
 ## Clear the Messages from the Message Store Database


### PR DESCRIPTION
update the quickstart instructions from `evt-pg-list-messages` to `evt-pg-print-messages`