### PR TITLE
Sidebar children are corrected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 *lock*
 _build
 diagrams/handler-workflow.png
+package.json*
+.vuepress/.cache
+.vuepress/.temp

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,19 +1,21 @@
-module.exports = {
+import { defaultTheme } from '@vuepress/theme-default';
+
+export default {
   title: 'Eventide',
   description: 'Pub/Sub, Event Sourcing, Evented Microservices',
   dest: './_build',
-  themeConfig: {
+  theme: defaultTheme({
     activeHeaderLinks: true,
-    nav: [
+    navbar: [
       { text: 'Home', link: '/' },
       {
-        text: 'Setup', items: [
+        text: 'Setup', children: [
           { text: 'Postgres', link: '/setup/postgres.md' },
           { text: 'EventStore', link: '/setup/eventstore.md' }
         ]
       },
       {
-        text: 'Core Concepts', items: [
+        text: 'Core Concepts', children: [
           { text: 'Streams', link: '/core-concepts/streams/' },
           { text: 'Services', link: '/core-concepts/services/' },
           { text: 'Messages and Messaging', link: '/core-concepts/messages-and-messaging/' },
@@ -22,7 +24,7 @@ module.exports = {
         ]
       },
       {
-        text: 'User Guide', items: [
+        text: 'User Guide', children: [
           { text: 'Message DB', link: '/user-guide/message-db/' },
           { text: 'Handlers', link: '/user-guide/handlers.md' },
           { text: 'Messages and Message Data', link: '/user-guide/messages-and-message-data/' },
@@ -45,7 +47,7 @@ module.exports = {
         ]
       },
       {
-        text: 'Examples', items: [
+        text: 'Examples', children: [
           { text: 'Overview', link: '/examples/' },
           { text: 'Service at a Glance', link: '/examples/at-a-glance.md' },
           { text: 'Quickstart', link: '/examples/quickstart.md' },
@@ -208,5 +210,5 @@ module.exports = {
         }
       ]
     }
-  }
+  })
 }

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,9 +1,11 @@
 import { defaultTheme } from '@vuepress/theme-default';
+import { searchPlugin } from '@vuepress/plugin-search';
 
 export default {
   title: 'Eventide',
   description: 'Pub/Sub, Event Sourcing, Evented Microservices',
   dest: './_build',
+  plugins: [searchPlugin()],
   theme: defaultTheme({
     activeHeaderLinks: true,
     navbar: [

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -77,7 +77,7 @@ export default {
           title: 'Streams',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'reading-and-writing.md',
             'uses-of-streams.md',
             'stream-names.md',
@@ -90,7 +90,7 @@ export default {
           title: 'Services',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'handlers.md',
             'entities.md',
             'projections.md',
@@ -105,7 +105,7 @@ export default {
           title: 'Messages and Messaging',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'messaging.md',
             'commands-and-events.md'
           ]
@@ -116,7 +116,7 @@ export default {
           title: 'Message DB',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'server-functions.md',
             'anatomy.md',
             'tools.md',
@@ -130,7 +130,7 @@ export default {
           title: 'Stream Names',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'messaging-stream-name.md',
             'messaging-category.md',
             'message-store-stream-name.md'
@@ -142,7 +142,7 @@ export default {
           title: 'Messages and Message Data',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'messages.md',
             'metadata.md',
             'message-data.md'
@@ -154,7 +154,7 @@ export default {
           title: 'Writing Messages',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'message-writer.md',
             'message-data-writer.md',
             'atomic-batches.md',
@@ -169,7 +169,7 @@ export default {
           title: 'Retrieving Messages',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'batch.md',
             'last.md'
           ]
@@ -180,7 +180,7 @@ export default {
           title: 'Entity Store, Caching, Snapshotting',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'entity-cache.md',
             'snapshotting.md',
             'substitute.md'
@@ -192,7 +192,7 @@ export default {
           title: 'Logging',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'log-tags.md'
           ]
         }
@@ -202,7 +202,7 @@ export default {
           title: 'Test Fixtures',
           collapsable: false,
           children: [
-            '',
+            'README.md',
             'handler-fixture.md',
             'message-fixture.md',
             'message-metadata-fixture.md',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -8,6 +8,8 @@ export default {
   plugins: [searchPlugin()],
   theme: defaultTheme({
     activeHeaderLinks: true,
+    colorMode: 'light',
+    colorModeSwitch: false,
     navbar: [
       { text: 'Home', link: '/' },
       {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ---
 home: true
 heroImage: /eventide-icon-132.png
+heroHeight: 131
 description: 'Pub/Sub, Event Sourcing, Evented Microservices'
 actionText: Get Started →
 actionLink: /examples/quickstart.md

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-vuepress build
+node_modules/.bin/vuepress build

--- a/install-vuepress.sh
+++ b/install-vuepress.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-npm install -g vuepress
+npm install vuepress@2.0.0-beta.60

--- a/install-vuepress.sh
+++ b/install-vuepress.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-npm install vuepress@2.0.0-beta.60
+npm install vuepress@2.0.0-beta.60 @vuepress/plugin-search@next

--- a/serve.sh
+++ b/serve.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-vuepress dev
+node_modules/.bin/vuepress dev

--- a/user-guide/code-generator.md
+++ b/user-guide/code-generator.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Component Code Generator

--- a/user-guide/component-host.md
+++ b/user-guide/component-host.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Component Host

--- a/user-guide/consumers.md
+++ b/user-guide/consumers.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Consumers

--- a/user-guide/entities.md
+++ b/user-guide/entities.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Entities

--- a/user-guide/handlers.md
+++ b/user-guide/handlers.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Handlers

--- a/user-guide/projection.md
+++ b/user-guide/projection.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Entity Projection

--- a/user-guide/reading.md
+++ b/user-guide/reading.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Reading Messages

--- a/user-guide/session.md
+++ b/user-guide/session.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Session

--- a/user-guide/settings.md
+++ b/user-guide/settings.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 0
+sidebarDepth: 1
 ---
 
 # Settings

--- a/user-guide/useful-objects.md
+++ b/user-guide/useful-objects.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-sidebarDepth: 1
+sidebarDepth: 2
 ---
 
 # The Doctrine of Useful Objects


### PR DESCRIPTION
Sidebar navigation links are duplicated once you navigate beyond the index and the index link is removed from sidebar.
![image](https://user-images.githubusercontent.com/3166322/220749902-225a6216-46b5-43c7-95ee-f31efe4c4f14.png)


The [documentation](https://v2.vuepress.vuejs.org/reference/default-theme/config.html#sidebar) for version `2.x`  of `vuepress` show using an explicit `README.md`, rather than an empty string for the index pages in the `sidebar` configuration.