### PR TITLE
Fix broken hyperlink to handlers

### DIFF
--- a/core-concepts/services/projections.md
+++ b/core-concepts/services/projections.md
@@ -4,7 +4,7 @@ sidebarDepth: 0
 
 # Projections
 
-An [entity's](./entities.md) data comes from the [events](/glossary.md#event) recorded in the entity's [event stream](/glossary.md#event-stream) as a result of [handlers](./handlers.md) handling commands and other events.
+An [entity's](./entities.md) data comes from the [events](/glossary.md#event) recorded in the entity's [event stream](/glossary.md#event-stream) as a result of [handlers](./message-handlers.md) handling commands and other events.
 
 A projection is the glue between an event stream and an entity.
 


### PR DESCRIPTION
Corrects the broken link to `handlers` on this page:
http://docs.eventide-project.org/core-concepts/services/projections.html