### PR TITLE
Fix links to writer documentation

### DIFF
--- a/user-guide/consumers.md
+++ b/user-guide/consumers.md
@@ -227,7 +227,7 @@ WHERE @hash_64(cardinal_id(stream_name)) % {group_size} = {group_member}
 ```
 
 ::: warning
-Consumer groups should always be used in conjunction with the concurrency protection offered by the message writer. Handler logic should always write messages using the writer's `expected_version` feature, irrespective of the use of consumer groups. However, the use of concurrency protection is even more imperative when using consumer groups. For more on concurrent writes, see the [writers user guide](/user-guide/writers/expected-version.md).
+Consumer groups should always be used in conjunction with the concurrency protection offered by the message writer. Handler logic should always write messages using the writer's `expected_version` feature, irrespective of the use of consumer groups. However, the use of concurrency protection is even more imperative when using consumer groups. For more on concurrent writes, see the [writers user guide](/user-guide/writing/expected-version.md).
 :::
 
 ## Filtering Messages with a SQL Condition

--- a/user-guide/logging/README.md
+++ b/user-guide/logging/README.md
@@ -250,13 +250,13 @@ Log messages at the `trace` level are typically worded to indicate that somethin
 
 ### Info Level
 
-The `info` level is used to log the completion of the principle operation of a class or utility, like a callable class or object's actuator. For example: A [message writer's](/user-guide/writers/message-writer.md) principle actuator.
+The `info` level is used to log the completion of the principle operation of a class or utility, like a callable class or object's actuator. For example: A [message writer's](/user-guide/writing/message-writer.md) principle actuator.
 
 Log messages at the `info` level are typically worded to indicate that something has been done or completed. The _ed_ past tense form of verbs is used in `trace` messages, for example "Wrote message".
 
 ### Debug Level
 
-The `debug` level is used to log the completion of a secondary operation of a class or utility, or for recording other details. For example: A [message writer's](/user-guide/writers/message-writer.md) secondary operation, like it's `initial` method or its `reply` method.
+The `debug` level is used to log the completion of a secondary operation of a class or utility, or for recording other details. For example: A [message writer's](/user-guide/writing/message-writer.md) secondary operation, like it's `initial` method or its `reply` method.
 
 Log messages at the `debug` level are typically worded to indicate that something has been done or completed. The _ed_ past tense form of verbs is used in `debug` messages, for example "Wrote initial message".
 

--- a/user-guide/logging/log-tags.md
+++ b/user-guide/logging/log-tags.md
@@ -236,7 +236,7 @@ The following tags _may_ be applied to log messages recorded by a message writer
 | message | Applied to log messages that record the writing of a typed message |
 | data | Applied to log messages that record the data content of a typed message |
 
-See the [message writer user guide](/user-guide/writers/message-writer.md) for more information on message writers.
+See the [message writer user guide](/user-guide/writing/message-writer.md) for more information on message writers.
 
 ## Message Data Writer
 
@@ -254,4 +254,4 @@ The following tags _may_ be applied to log messages recorded by a message data w
 | message_data | Applied to log messages that record the writing of a MessageData instance |
 | data | Applied to log messages that record the data content of a MessageData instance |
 
-See the [message data writer user guide](/user-guide/writers/message-data-writer.md) for more information on message data writers.
+See the [message data writer user guide](/user-guide/writing/message-data-writer.md) for more information on message data writers.

--- a/user-guide/messages-and-message-data/metadata.md
+++ b/user-guide/messages-and-message-data/metadata.md
@@ -63,7 +63,7 @@ Additionally, a message's metadata may carry a _reply address_:
 
 - `reply_stream_name`
 
-See the [Messaging::Writer](../writers/messaging-writer.md) user guide for more on replying to messages.
+See the [Messaging::Writer](../writing/message-writer.md) user guide for more on replying to messages.
 
 ### Metadata Data Transfer
 


### PR DESCRIPTION
This fixes a handful of links that are currently broken.